### PR TITLE
Feat: Implement Test Section Order and Visibility Updates for Practice, Homework, and Attempted Tests

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -38,6 +38,14 @@ export default function Home() {
       quizCompletionStatus[platformId] === false;
   };
 
+  /**
+ * Filters and sorts quizzes into different categories such as non-chapter tests,
+ * chapter tests, practice tests, and homework. This method is essential for the Gurukul
+ * platform to categorize and display tests efficiently, allowing users to quickly identify
+ * the type of tests they need to attempt based on their purpose (e.g., chapter tests or practice tests).
+ * The separation ensures a clear structure in the UI, enhancing user experience by organizing
+ * tests by relevance.
+ */
   const filterAndSortTests = (quizzes: QuizSession[]) => {
     const activeQuizzes = quizzes
       .filter(quiz => isSessionActive(formatQuizSessionTime(quiz.session.end_time)))

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,7 +5,7 @@ import TopBar from "@/components/TopBar";
 import BottomNavigationBar from "@/components/BottomNavigationBar";
 import { getSessionOccurrences, fetchUserSession } from "@/api/afdb/session";
 import { useState, useEffect } from "react";
-import { QuizSession, SessionOccurrence, MessageDisplayProps, Session } from "./types";
+import { QuizSession, SessionOccurrence, MessageDisplayProps, Session, QuizCompletionStatus } from "./types";
 import Link from "next/link";
 import PrimaryButton from "@/components/Button";
 import Loading from "./loading";
@@ -18,9 +18,49 @@ export default function Home() {
   const [liveClasses, setLiveClasses] = useState<SessionOccurrence[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [quizzes, setQuizzes] = useState<QuizSession[]>([]);
+  const [quizCompletionStatus, setQuizCompletionStatus] = useState<QuizCompletionStatus>({});
   const commonTextClass = "text-gray-700 text-xs md:text-sm mx-3 md:mx-8 whitespace-nowrap w-12";
   const infoMessageClass = "flex items-center justify-center text-center h-72 mx-4 pb-40";
   const portalBaseUrl = api.portal.frontend.baseUrl;
+
+  const fetchQuizCompletionStatus = async () => {
+    try {
+      const response = await fetch(`${process.env.NEXT_PUBLIC_PROD_QUIZ_BACKEND_URL}sessions/user/${userId}/quiz-attempts`);
+      const data = await response.json();
+      setQuizCompletionStatus(data);
+    } catch (error) {
+      console.error("Error fetching quiz completion status:", error);
+    }
+  };
+
+  const isQuizAttemptable = (platformId: string) => {
+    return !quizCompletionStatus.hasOwnProperty(platformId) ||
+      quizCompletionStatus[platformId] === false;
+  };
+
+  const filterAndSortTests = (quizzes: QuizSession[]) => {
+    const activeQuizzes = quizzes
+      .filter(quiz => isSessionActive(formatQuizSessionTime(quiz.session.end_time)))
+      .filter(quiz => isQuizAttemptable(quiz.session.platform_id));
+
+    const nonChapterTests = activeQuizzes.filter(quiz =>
+      quiz.session.meta_data.test_format !== 'chapter_test'
+    );
+
+    const chapterTests = activeQuizzes.filter(quiz =>
+      quiz.session.meta_data.test_format === 'chapter_test'
+    );
+
+    const practiceTests = activeQuizzes.filter(quiz =>
+      quiz.session.meta_data.test_purpose === 'practice_test'
+    );
+
+    const homework = activeQuizzes.filter(quiz =>
+      quiz.session.meta_data.test_type === 'homework'
+    );
+
+    return { nonChapterTests, chapterTests, practiceTests, homework };
+  };
 
   const fetchUserSessions = async () => {
     try {
@@ -53,6 +93,93 @@ export default function Home() {
     }
   };
 
+  const renderLiveClasses = () => {
+    if (liveClasses.length === 0) {
+      return <MessageDisplay message="No more live classes are scheduled for today!" />;
+    }
+
+    return (
+      <div className="grid grid-cols-1 gap-4 pb-16">
+        {liveClasses.map((data, index) => (
+          isSessionActive(formatSessionTime(data.end_time)) && (
+            <div key={index} className="flex mt-4 items-center">
+              <div>
+                <p className={commonTextClass}>
+                  {format12HrSessionTime(data.start_time)}
+                </p>
+                <p className={commonTextClass}>
+                  {format12HrSessionTime(data.end_time)}
+                </p>
+              </div>
+              <div className="bg-white rounded-lg shadow-lg min-h-24 h-auto py-6 relative w-full flex flex-row justify-between mr-4 items-center">
+                <div className={`${index % 2 === 0 ? 'bg-orange-200' : 'bg-red-200'} h-full w-2 absolute left-0 top-0 rounded-s-md`}></div>
+                <div className="text-sm md:text-base mx-6 md:mx-8 w-36">
+                  <span className="font-semibold">{data.session.meta_data.subject ?? "Science"} </span>
+                  <div className="text-sm md:text-base">
+                    {data.session.name}
+                  </div>
+                </div>
+                {renderButton(data)}
+              </div>
+            </div>
+          )
+        ))}
+        {liveClasses.filter((data) => isSessionActive(formatSessionTime(data.end_time))).length === 0 && (
+          <MessageDisplay message="No more live classes are scheduled for today!" />
+        )}
+      </div>
+    );
+  };
+
+  const renderTestSection = (title: string, tests: QuizSession[]) => {
+    if (tests.length === 0 && title === "Tests") {
+      return (
+        <div>
+          <h2 className="text-primary ml-4 font-semibold text-lg mt-6">{title}</h2>
+          <MessageDisplay message="No more tests are scheduled for today!" />
+        </div>
+      );
+    }
+    if (tests.length === 0) return null;
+
+    return (
+      <div>
+        <h2 className="text-primary ml-4 font-semibold text-lg mt-6">{title}</h2>
+        <div className="grid grid-cols-1 gap-4 pb-4">
+          {tests.map((data, index) => (
+            <div key={index} className="flex mt-4 items-center">
+              <div>
+                <p className={commonTextClass}>
+                  {format12HrSessionTime(data.session.start_time)}
+                </p>
+                <p className={commonTextClass}>
+                  {format12HrSessionTime(data.session.end_time)}
+                </p>
+              </div>
+              <div className="bg-white rounded-lg shadow-lg min-h-24 h-auto py-6 relative w-full flex flex-row justify-between mr-4 items-center">
+                <div className={`${index % 2 === 0 ? 'bg-orange-200' : 'bg-red-200'} h-full w-2 absolute left-0 top-0 rounded-s-md`}></div>
+                <div className="text-sm md:text-base mx-6 md:mx-8">
+                  <div className="flex w-36">
+                    <span className="font-semibold">{data.session.name}</span>
+                  </div>
+                  <div className="text-sm md:text-base">
+                    <span>{data.session.meta_data.test_format}</span>
+                  </div>
+                  {quizCompletionStatus.hasOwnProperty(data.session.platform_id) && !quizCompletionStatus[data.session.platform_id] && (
+                    <div className="text-yellow-600 text-xs mt-1">
+                      Resume test
+                    </div>
+                  )}
+                </div>
+                {renderButton(data.session)}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  };
+
   function renderButton(data: any) {
     const currentTime = new Date();
     const sessionStartTimeStr = formatSessionTime(data.start_time);
@@ -63,14 +190,15 @@ export default function Home() {
     const sessionEndTime = new Date(`2000-01-01T${sessionEndTimeStr}`);
     const currentTimeObj = new Date(`2000-01-01T${currentTimeStr}`);
     const minutesUntilSessionStart = (sessionTime.getTime() - currentTimeObj.getTime()) / (1000 * 60);
-    const hasSessionNotEnded = sessionEndTime.getTime() > currentTimeObj.getTime()
+    const hasSessionNotEnded = sessionEndTime.getTime() > currentTimeObj.getTime();
 
     if (data.session && data.session.platform === 'meet') {
       if (minutesUntilSessionStart <= 5 && hasSessionNotEnded) {
         return (
           <Link href={`${portalBaseUrl}/?sessionId=${data.session.session_id}`} target="_blank">
-            <PrimaryButton
-              className="bg-primary text-white text-sm rounded-lg w-12 h-8 mr-4 shadow-md shadow-slate-400">JOIN</PrimaryButton>
+            <PrimaryButton className="bg-primary text-white text-sm rounded-lg w-12 h-8 mr-4 shadow-md shadow-slate-400">
+              JOIN
+            </PrimaryButton>
           </Link>
         );
       } else {
@@ -81,13 +209,17 @@ export default function Home() {
           </p>
         );
       }
-    }
-    else if (data.platform === 'quiz') {
+    } else if (data.platform === 'quiz') {
       if (minutesUntilSessionStart <= 5 && hasSessionNotEnded) {
+        const buttonText = quizCompletionStatus.hasOwnProperty(data.session_id) && !quizCompletionStatus[data.session_id]
+          ? "RESUME"
+          : "START";
+
         return (
           <Link href={`${portalBaseUrl}/?sessionId=${data.session_id}`} target="_blank">
-            <PrimaryButton
-              className="bg-primary text-white text-sm rounded-lg w-16 h-8 mr-4 shadow-md shadow-slate-400">START</PrimaryButton>
+            <PrimaryButton className="bg-primary text-white text-sm rounded-lg w-16 h-8 mr-4 shadow-md shadow-slate-400">
+              {buttonText}
+            </PrimaryButton>
           </Link>
         );
       } else {
@@ -106,24 +238,27 @@ export default function Home() {
     return <p className={infoMessageClass}>{message}</p>;
   }
 
-  const fetchData = async () => {
-    setIsLoading(true);
-    try {
-      if (userDbId !== null) {
-        await fetchUserSessions();
-        setIsLoading(false);
-      }
-    } catch (error) {
-      console.log("Error:", error);
-      setIsLoading(false);
-    }
-  };
-
   useEffect(() => {
     if (loggedIn) {
+      const fetchData = async () => {
+        setIsLoading(true);
+        try {
+          if (userDbId !== null) {
+            await Promise.all([
+              fetchUserSessions(),
+              fetchQuizCompletionStatus()
+            ]);
+          }
+        } catch (error) {
+          console.log("Error:", error);
+        }
+        setIsLoading(false);
+      };
       fetchData();
     }
   }, [loggedIn, userDbId]);
+
+  const { nonChapterTests, chapterTests, practiceTests, homework } = filterAndSortTests(quizzes);
 
   return (
     <>
@@ -137,74 +272,17 @@ export default function Home() {
           <TopBar />
           <div>
             <h1 className="text-primary ml-4 font-semibold text-xl pt-6">Live Classes</h1>
-            {liveClasses.length > 0 ? (
-              <div className="grid grid-cols-1 gap-4 pb-16">
-                {liveClasses.map((data, index) => (isSessionActive(formatSessionTime(data.end_time)) &&
-                  <div key={index} className="flex mt-4 items-center" >
-                    <div>
-                      <p className={`${commonTextClass}`}>
-                        {format12HrSessionTime(data.start_time)}
-                      </p>
-                      <p className={`${commonTextClass}`}>
-                        {format12HrSessionTime(data.end_time)}
-                      </p>
-                    </div>
-                    <div className="bg-white rounded-lg shadow-lg min-h-24 h-auto py-6 relative w-full flex flex-row justify-between mr-4 items-center">
-                      <div className={`${index % 2 === 0 ? 'bg-orange-200' : 'bg-red-200'} h-full w-2 absolute left-0 top-0 rounded-s-md`}></div>
-                      <div className="text-sm md:text-base mx-6 md:mx-8 w-36">
-                        <span className="font-semibold">{data.session.meta_data.subject ?? "Science"} </span>
-                        <div className="text-sm md:text-base ">
-                          {data.session.name}
-                        </div>
-                      </div>
-                      {renderButton(data)}
-                    </div>
-                  </div>
-                ))}
-                {liveClasses.filter((data) => isSessionActive(formatSessionTime(data.end_time))).length === 0 && (
-                  <MessageDisplay message="No more live classes are scheduled for today!" />
-                )}
-              </div>) : (
-              <MessageDisplay message="No more live classes are scheduled for today!" />
-            )}
+            {renderLiveClasses()}
           </div>
-          <div>
-            <h1 className="text-primary ml-4 font-semibold text-xl">Tests</h1>
-            {quizzes.length > 0 ? (
-              <div className="grid grid-cols-1 gap-4 pb-40">
-                {quizzes.map((data, index) => (isSessionActive(formatQuizSessionTime(data.session.end_time)) &&
-                  <div key={index} className="flex mt-4 items-center" >
-                    <div>
-                      <p className={`${commonTextClass}`}>
-                        {format12HrSessionTime(data.session.start_time)}
-                      </p>
-                      <p className={`${commonTextClass}`}>
-                        {format12HrSessionTime(data.session.end_time)}
-                      </p>
-                    </div>
-                    <div className="bg-white rounded-lg shadow-lg min-h-24 h-auto py-6 relative w-full flex flex-row justify-between mr-4 items-center">
-                      <div className={`${index % 2 === 0 ? 'bg-orange-200' : 'bg-red-200'} h-full w-2 absolute left-0 top-0  rounded-s-md`}></div>
-                      <div className="text-sm md:text-base mx-6 md:mx-8">
-                        <div className="flex w-36">
-                          <span className="font-semibold">{data.session.name}</span>
-                        </div>
-                        <div className="text-sm md:text-base">
-                          <span>{data.session.meta_data.test_format}</span>
-                        </div>
-                      </div>
-                      {renderButton(data.session)}
-                    </div>
-                  </div>
-                ))}
-                {quizzes.filter((data) => isSessionActive(formatQuizSessionTime(data.session.end_time))).length === 0 && (
-                  <MessageDisplay message="No more tests are scheduled for today!" />
-                )}
-              </div>) : (
-              <MessageDisplay message="No more tests are scheduled for today!" />
-            )}
+
+          <div className="pb-40">
+            {renderTestSection("Tests", [...nonChapterTests, ...chapterTests])}
+            {renderTestSection("Practice Tests", practiceTests)}
+            {renderTestSection("Homework", homework)}
           </div>
           <BottomNavigationBar />
-        </main>)}
+        </main>
+      )}
     </>
   );
 }

--- a/app/types.ts
+++ b/app/types.ts
@@ -127,13 +127,16 @@ export interface QuizSession {
     end_date: string,
     end_time: string,
     meta_data: {
-      test_format: string
+      test_format: string,
+      test_purpose: string,
+      test_type: string
     }
     start_date: string,
     start_time: string,
     name: string,
     subject: string,
     id: string,
+    platform_id: string,
   },
 }
 
@@ -148,4 +151,8 @@ export interface SessionOccurrence {
 
 export interface MessageDisplayProps {
   message: string;
+}
+
+export interface QuizCompletionStatus {
+  [key: string]: boolean;
 }


### PR DESCRIPTION
### Description
- Display non-chapter tests (test_format≠chapter_test) first, followed by chapter tests (test_format==chapter_test) under the test section.
- Added section for practice tests (test_purpose == practice_test).
- Added section for homework tests (test_type == homework).
- Ensured that attempted tests are no longer visible on Gurukul.

https://www.notion.so/avantifellows/Changes-in-Gurukul-for-Enable-Rollout-115d19b3111c807cadc6e0417ea82596

### Checklist
- [x] Local testing