### PR TITLE
Use apaar_id for EnableStudents group and refactor user fetching logic

### DIFF
--- a/api/afdb/userName.ts
+++ b/api/afdb/userName.ts
@@ -3,13 +3,13 @@
 import getFetchConfig from '../fetchConfig';
 import { Student, User } from '@/app/types';
 
-export const getUserName = async (studentId: string): Promise<User | null> => {
+export const getUserName = async (id: string, idType: 'student_id' | 'apaar_id' = 'student_id'): Promise<User | null> => {
     const url = process.env.AF_DB_SERVICE_URL;
     const bearerToken = process.env.AF_DB_SERVICE_BEARER_TOKEN!;
 
     try {
         const queryParams = new URLSearchParams({
-            student_id: studentId,
+            [idType]: id,
         });
 
         const urlWithParams = `${url}/student?${queryParams.toString()}`;
@@ -22,7 +22,7 @@ export const getUserName = async (studentId: string): Promise<User | null> => {
         const data: Student[] = await response.json();
 
         if (data.length === 0) {
-            console.warn(`No user found for student ID: ${studentId}`);
+            console.warn(`No user found for student ID: ${id}`);
             return null;
         }
 

--- a/services/AuthContext.tsx
+++ b/services/AuthContext.tsx
@@ -31,9 +31,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
                 const result = await verifyToken();
                 if (result.isValid) {
                     setLoggedIn(true);
+                    const userGroup = result.data.data.group;
                     setUserId(result.data.id);
-                    setGroup(result.data.data.group);
-                    const userData = await getUserName(result.data.id);
+                    setGroup(userGroup);
+                    const idType = userGroup === "EnableStudents" ? 'apaar_id' : 'student_id';
+                    const userData = await getUserName(result.data.id, idType);
                     setUser(userData);
                 } else {
                     setLoggedIn(false);


### PR DESCRIPTION
### Description

This PR updates the authentication and user fetching logic to support students in the **EnableStudents** group, who should be identified by their `apaar_id` instead of the default `student_id`. The changes ensure that:

- For all users, `setUserId` is always called with `result.data.id` for consistency.
- When fetching user details, the `getUserName` function now accepts an `idType` parameter, allowing it to query by either `student_id` or `apaar_id`.
- For users in the **EnableStudents** group, `getUserName` is called with `idType='apaar_id'`; for all others, it defaults to `student_id`.
- Duplicate code in the authentication logic has been removed for clarity and maintainability.

---

#### Changes Made

- Refactored `getUserName` in `api/afdb/userName.ts` to accept an `idType` parameter and use it as the query key.
- Updated `AuthContext.tsx` to:
  - Always use `setUserId(result.data.id)`.
  - Dynamically select the correct `idType` for `getUserName` based on the user's group.
  - Remove duplicate logic for setting user ID and fetching user details.
- **Minor**: Restored redirect to the login page for invalid tokens.

---

#### Why?

This change is necessary to support the new identification system for the **EnableStudents** group, which uses `apaar_id` as the primary identifier, while maintaining backward compatibility for other groups.
