### PR TITLE
Feat: Update student fetch logic to pass `id` and `group` for consistent backend querying

### DIFF
--- a/api/afdb/userName.ts
+++ b/api/afdb/userName.ts
@@ -3,13 +3,17 @@
 import getFetchConfig from '../fetchConfig';
 import { Student, User } from '@/app/types';
 
-export const getUserName = async (id: string, idType: 'student_id' | 'apaar_id' = 'student_id'): Promise<User | null> => {
+export const getUserName = async (
+    id: string,
+    group: string
+): Promise<User | null> => {
     const url = process.env.AF_DB_SERVICE_URL;
     const bearerToken = process.env.AF_DB_SERVICE_BEARER_TOKEN!;
 
     try {
         const queryParams = new URLSearchParams({
-            [idType]: id,
+            id,
+            group,
         });
 
         const urlWithParams = `${url}/student?${queryParams.toString()}`;
@@ -22,7 +26,7 @@ export const getUserName = async (id: string, idType: 'student_id' | 'apaar_id' 
         const data: Student[] = await response.json();
 
         if (data.length === 0) {
-            console.warn(`No user found for student ID: ${id}`);
+            console.warn(`No user found for id: ${id}, group: ${group}`);
             return null;
         }
 

--- a/services/AuthContext.tsx
+++ b/services/AuthContext.tsx
@@ -34,13 +34,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
                     const userGroup = result.data.data.group;
                     setUserId(result.data.id);
                     setGroup(userGroup);
-                    let userData = null;
-                    if (userGroup === "EnableStudents") {
-                        userData = await getUserName(result.data.id, 'apaar_id');
-                    }
-                    if (!userData) {
-                        userData = await getUserName(result.data.id, 'student_id');
-                    }
+                    const userData = await getUserName(result.data.id, userGroup);
                     setUser(userData);
                 } else {
                     setLoggedIn(false);


### PR DESCRIPTION
### Description
This PR updates the frontend logic to align with the logic for fetching student details. Previously, the frontend handled logic to decide whether to query by `student_id` or `apaar_id` based on the user's group. This logic has now been shifted to the backend for better maintainability.

### Changes Made:
- Updated the getUserName function to send id and group as query parameters (/student?id=...&group=...).
- Removed conditional logic in AuthProvider for determining idType (apaar_id vs student_id).
- Simplified userData assignment using const.
- This ensures a cleaner frontend and allows future group-specific logic to be handled entirely on the backend side.


### Checklist
- [x] Local testing