### PR TITLE
Feat: Add support for chapters across all grades

### DIFF
--- a/api/afdb/library.ts
+++ b/api/afdb/library.ts
@@ -42,13 +42,31 @@ export const getChapters = async (
   id?: number,
   curriculumId?: number
 ): Promise<Chapter[]> => {
+  // Get all chapters for the subject
   const queryParams = new URLSearchParams();
   if (id) queryParams.append('id', id.toString());
   if (subjectId) queryParams.append('subject_id', subjectId.toString());
-  if (gradeId) queryParams.append('grade_id', gradeId.toString());
   if (curriculumId) queryParams.append('curriculum_id', curriculumId.toString());
 
-  return fetchWithParams('chapter', queryParams);
+  const allChapters: Chapter[] = await fetchWithParams('chapter', queryParams);
+
+  // Filter chapters to include:
+  // 1. Chapters for the specific grade (grade_id matches)
+  // 2. Universal chapters (grade_id is null)
+  const filteredChapters = allChapters.filter(chapter => {
+    // If no gradeId is provided, return all chapters
+    if (!gradeId) return true;
+
+    // Include chapters for the specific grade
+    if (chapter.grade_id === gradeId) return true;
+
+    // Include universal chapters (grade_id is null)
+    if (chapter.grade_id === null || chapter.grade_id === undefined) return true;
+
+    return false;
+  });
+
+  return filteredChapters;
 };
 
 export const getTopics = async (chapterIds: number[]): Promise<Topic[]> => {

--- a/api/afdb/library.ts
+++ b/api/afdb/library.ts
@@ -61,7 +61,7 @@ export const getChapters = async (
     if (chapter.grade_id === gradeId) return true;
 
     // Include universal chapters (grade_id is null)
-    if (chapter.grade_id === null || chapter.grade_id === undefined) return true;
+    if (!chapter.grade_id) return true;
 
     return false;
   });

--- a/api/afdb/library.ts
+++ b/api/afdb/library.ts
@@ -50,15 +50,18 @@ export const getChapters = async (
 
   const allChapters: Chapter[] = await fetchWithParams('chapter', queryParams);
 
+  // If no gradeId is provided, return all chapters
+  if (!gradeId) return allChapters;
+
   // Filter chapters to include:
   // 1. Chapters for the specific grade (grade_id matches)
   // 2. Universal chapters (grade_id is null)
   const filteredChapters = allChapters.filter(chapter => {
-    // If no gradeId is provided or chapter has no grade, return all chapters
-    if (!gradeId || !chapter.grade_id) return true;
-
     // Include chapters for the specific grade
     if (chapter.grade_id === gradeId) return true;
+
+    // Include universal chapters (grade_id is null)
+    if (!chapter.grade_id) return true;
 
     return false;
   });

--- a/api/afdb/library.ts
+++ b/api/afdb/library.ts
@@ -54,14 +54,11 @@ export const getChapters = async (
   // 1. Chapters for the specific grade (grade_id matches)
   // 2. Universal chapters (grade_id is null)
   const filteredChapters = allChapters.filter(chapter => {
-    // If no gradeId is provided, return all chapters
-    if (!gradeId) return true;
+    // If no gradeId is provided or chapter has no grade, return all chapters
+    if (!gradeId || !chapter.grade_id) return true;
 
     // Include chapters for the specific grade
     if (chapter.grade_id === gradeId) return true;
-
-    // Include universal chapters (grade_id is null)
-    if (!chapter.grade_id) return true;
 
     return false;
   });

--- a/api/afdb/library.ts
+++ b/api/afdb/library.ts
@@ -57,11 +57,8 @@ export const getChapters = async (
   // 1. Chapters for the specific grade (grade_id matches)
   // 2. Universal chapters (grade_id is null)
   const filteredChapters = allChapters.filter(chapter => {
-    // Include chapters for the specific grade
-    if (chapter.grade_id === gradeId) return true;
-
-    // Include universal chapters (grade_id is null)
-    if (!chapter.grade_id) return true;
+    // Include chapters for the specific grade or universal chapters
+    if (chapter.grade_id === gradeId || !chapter.grade_id) return true;
 
     return false;
   });

--- a/app/types.ts
+++ b/app/types.ts
@@ -55,6 +55,7 @@ export interface Grade {
 export interface Chapter {
   id: number;
   name: string;
+  grade_id?: number | null;
 }
 
 export interface Resource {


### PR DESCRIPTION
### Description
- **Modified `getChapters()` function**: Now fetches all chapters for a subject and filters them to include both grade-specific and universal chapters
- **Updated Chapter type**: Added `grade_id?: number | null` property to support filtering

### Checklist
- [x] Local testing

