### PR TITLE
Fix: Prevent unnecessary API call when no sessions exist

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -98,6 +98,14 @@ export default function Home() {
       ]);
 
       const sessionIds = [...liveSessionData, ...quizSessionData].map(session => session.session_id);
+
+      // Added Guard Clause to avoid fetching session occurrences if there are no sessions
+      if (sessionIds.length === 0) {
+        setQuizzes([]);
+        setLiveClasses([]);
+        return;
+      }
+
       const sessionOccurrences = await getSessionOccurrences(sessionIds);
 
       const quizSessions = sessionOccurrences.filter((sessionOccurence: SessionOccurrence) => sessionOccurence.session.platform === 'quiz');


### PR DESCRIPTION
### Problem
The getSessionOccurrences API was being called even when sessionIds was empty, causing the API to return all sessions instead of an empty result. This led to sessions being displayed for users who shouldn't have access to them.

### Solution
Added a guard clause to prevent the API call when sessionIds array is empty, ensuring that:
- No unnecessary API calls are made
- Empty state is handled correctly
- Users only see sessions they have access to

### Changes Made
- Added guard clause in fetchUserSessions() function
- Early return when sessionIds.length === 0
- Set empty arrays for quizzes and liveClasses when no sessions exist

