### PR TITLE
Restore landing page for unauthenticated users

### DIFF
--- a/services/AuthContext.tsx
+++ b/services/AuthContext.tsx
@@ -151,10 +151,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
                     setGroup(identity.group);
 
                     if (!identity.userId || !identity.group) {
-                        console.warn('Token verification missing identifiers, redirecting to portal');
+                        console.warn('Token verification missing identifiers');
                         setLoggedIn(false);
                         clearIdentityState();
-                        redirectToPortal();
                         return;
                     }
 
@@ -190,7 +189,6 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
                 } else {
                     setLoggedIn(false);
                     clearIdentityState();
-                    redirectToPortal();
                 }
             } catch (error) {
                 console.error('Error verifying token:', error);


### PR DESCRIPTION
## Summary
- PR #131 reintroduced `redirectToPortal()` calls in `checkToken` (failed-token branch and missing-identifier branch), which overrode the landing-page behavior added in PR #156.
- Result: unauthenticated visitors were again being redirected to the `DelhiStudents` portal instead of seeing the public landing page rendered by `AuthGate`.
- This PR removes those two auto-redirects so `AuthGate` can show `LandingPage` for any unauthenticated user, on any route.
- Logout still calls `redirectToPortal()` — the post-logout portal handoff is intentionally preserved.

## Test plan
- [ ] Clear cookies / open incognito and visit `/` → should see landing page (not redirect to portal)
- [ ] Visit `/library` or `/reports` without auth → should see landing page
- [ ] Visit `/login` → should still see group selection page
- [ ] Log in with a valid token → should see normal app home page
- [ ] Log out → should still redirect to the portal for the user's group
- [ ] Simulate a token that verifies but is missing `user_id`/`group` → should fall through to landing page (with a console warning), not redirect

🤖 Generated with [Claude Code](https://claude.com/claude-code)