### PR TITLE
feat: resolve Gurukul UI config from db-service

### DIFF
--- a/api/afdb/gurukulConfig.ts
+++ b/api/afdb/gurukulConfig.ts
@@ -1,0 +1,41 @@
+"use server";
+
+import getFetchConfig from '../fetchConfig';
+import { GroupConfig } from '@/app/types';
+
+/**
+ * Fetches the resolved Gurukul UI configuration for a user from db-service.
+ *
+ * db-service resolves the config along the fallback chain
+ * `defaultgroup <- program <- batch` (later layers win) based on the user's
+ * oldest current batch/program enrollment.
+ *
+ * Returns a partial config containing only the keys configured on the backend.
+ * Callers overlay it on the hardcoded group defaults, so an empty response (or
+ * a failure) simply leaves the existing defaults in place.
+ */
+export const fetchGurukulConfig = async (
+    user_id: string
+): Promise<Partial<GroupConfig>> => {
+    const url = process.env.AF_DB_SERVICE_URL;
+    const bearerToken = process.env.AF_DB_SERVICE_BEARER_TOKEN!;
+
+    try {
+        const queryParams = new URLSearchParams({ user_id });
+        const urlWithParams = `${url}/gurukul-config?${queryParams.toString()}`;
+        const response = await fetch(urlWithParams, {
+            ...getFetchConfig(bearerToken),
+            cache: 'no-store',
+        });
+
+        if (!response.ok) {
+            throw new Error(`Error fetching gurukul config: ${response.statusText}`);
+        }
+
+        const data: { config?: Partial<GroupConfig> | null } = await response.json();
+        return data.config ?? {};
+    } catch (error) {
+        console.error('Error fetching gurukul config:', error);
+        return {};
+    }
+};

--- a/app/library/page.tsx
+++ b/app/library/page.tsx
@@ -16,14 +16,12 @@ import { FaRupeeSign } from 'react-icons/fa';
 import { MixpanelTracking } from '@/services/mixpanel';
 import { MIXPANEL_EVENT } from '@/constants/config';
 import { useAuth } from '@/services/AuthContext';
-import { getGroupConfig } from '@/config/groupConfig';
 import { ReactNode } from 'react';
 
 const Page: React.FC = () => {
   const [selectedLibrary, setSelectedLibrary] = useState<string | null>('Content');
   const { push } = useRouter();
-  const { group } = useAuth();
-  const groupConfig = getGroupConfig(group || 'defaultGroup');
+  const { groupConfig } = useAuth();
 
   const handleLibraryChange = (library: string) => {
     MixpanelTracking.getInstance().trackEvent(MIXPANEL_EVENT.SELECTED_LIBRARY, { library_name: library });

--- a/app/loading.js
+++ b/app/loading.js
@@ -2,11 +2,9 @@
 
 import { useAuth } from "@/services/AuthContext";
 import BottomNavigationBar from "@/components/BottomNavigationBar";
-import { getGroupConfig } from "@/config/groupConfig";
 
 export default function Loading({ showReportsOnly = false, showLibraryOnly = false, showChapterContentOnly = false, cardCount = 3 }) {
-    const { group } = useAuth();
-    const groupConfig = getGroupConfig(group || 'defaultGroup');
+    const { groupConfig } = useAuth();
 
     const ShimmerCard = ({ showTimeColumn = false }) => (
         <div className="flex mt-4 items-center animate-pulse">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,13 +11,11 @@ import PrimaryButton from "@/components/Button";
 import Loading from "./loading";
 import { formatCurrentTime, formatSessionTime, formatQuizSessionTime, formatTime, isSessionActive, format12HrSessionTime } from "@/utils/dateUtils";
 import { MixpanelTracking } from "@/services/mixpanel";
-import { getGroupConfig } from "@/config/groupConfig";
 import { IoIosArrowDown as ExpandIcon, IoIosArrowUp as CollapseIcon } from 'react-icons/io';
 import { buildGurukulSessionUrl } from "@/utils/portalLinks";
 
 export default function Home() {
-  const { loggedIn, userId, group, isLoading: authLoading } = useAuth();
-  const groupConfig = getGroupConfig(group || 'defaultGroup');
+  const { loggedIn, userId, group, groupConfig, isLoading: authLoading } = useAuth();
   const [liveClasses, setLiveClasses] = useState<SessionOccurrence[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [quizzes, setQuizzes] = useState<QuizSession[]>([]);
@@ -93,7 +91,6 @@ export default function Home() {
   const fetchUserSessions = async () => {
     setIsLoading(true);
     try {
-      const groupConfig = getGroupConfig(group || 'defaultGroup');
       const shouldFetchQuizzes = groupConfig.showTests || groupConfig.showPracticeTests || groupConfig.showHomework;
 
       const numericUserId = Number(userId);

--- a/app/reports/reports_list.tsx
+++ b/app/reports/reports_list.tsx
@@ -7,13 +7,11 @@ import { MixpanelTracking } from "@/services/mixpanel";
 import { MIXPANEL_EVENT } from "@/constants/config";
 import { formatDate } from "@/utils/dateUtils";
 import { useAuth } from "@/services/AuthContext";
-import { getGroupConfig } from "@/config/groupConfig";
 
 export default function ReportsList({ userId }: ReportsListProps) {
     const [responseData, setResponseData] = useState<{ reports: Report[] } | null>(null);
     const [isLoading, setIsLoading] = useState(true);
-    const { group } = useAuth();
-    const groupConfig = getGroupConfig(group || 'defaultGroup');
+    const { groupConfig } = useAuth();
 
     useEffect(() => {
         async function fetchReportsData() {

--- a/app/types.ts
+++ b/app/types.ts
@@ -14,6 +14,7 @@ export interface AuthContextProps {
   apaarId: string | null;
   logout: () => void;
   isLoading: boolean;
+  groupConfig: GroupConfig;
 }
 
 export interface CurrentTimeProps {

--- a/components/BottomNavigationBar.tsx
+++ b/components/BottomNavigationBar.tsx
@@ -9,13 +9,11 @@ import { IoHome, IoHomeOutline } from 'react-icons/io5';
 import CapgeminiLogo from '../assets/capgemini_logo.png'
 import TataMotorsLogo from '../assets/tata_motors_logo.png'
 import { BottomNavigationBarProps } from '@/app/types';
-import { getGroupConfig } from '@/config/groupConfig';
 import { useAuth } from '@/services/AuthContext';
 
 const BottomNavigationBar = ({ homeLabel }: BottomNavigationBarProps) => {
   const pathname = usePathname();
-  const { group } = useAuth();
-  const groupConfig = getGroupConfig(group || 'defaultGroup');
+  const { groupConfig } = useAuth();
   const sponsorLogosMode = groupConfig.homepageSponsorLogos ?? 'default';
 
   // Determine the home label from config or provided prop

--- a/services/AuthContext.tsx
+++ b/services/AuthContext.tsx
@@ -1,10 +1,11 @@
 "use client"
 
-import React, { createContext, useContext, useState, useEffect } from 'react';
+import React, { createContext, useContext, useState, useEffect, useMemo } from 'react';
 import { verifyToken } from '@/services/validation';
 import { usePathname, useRouter } from 'next/navigation';
 import {
     AuthContextProps,
+    GroupConfig,
     ResolvedTokenIdentity,
     Student,
     TokenProfile,
@@ -13,6 +14,7 @@ import {
 } from '../app/types';
 import { api } from '@/services/url';
 import { getUserDetails } from '@/api/afdb/userDetails';
+import { fetchGurukulConfig } from '@/api/afdb/gurukulConfig';
 import { getGroupConfig } from '@/config/groupConfig';
 import { MixpanelTracking } from '@/services/mixpanel';
 import { MIXPANEL_EVENT } from '@/constants/config';
@@ -119,6 +121,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     const [group, setGroup] = useState<string | null>(null);
     const [studentId, setStudentId] = useState<string | null>(null);
     const [apaarId, setApaarId] = useState<string | null>(null);
+    const [remoteConfig, setRemoteConfig] = useState<Partial<GroupConfig>>({});
     const [isLoading, setIsLoading] = useState(true);
 
     const clearIdentityState = () => {
@@ -181,8 +184,14 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
                         }
                     }
 
+                    // Resolve UI config from db-service (batch <- program <-
+                    // defaultgroup). Falls back to the hardcoded group defaults
+                    // when the backend has nothing configured for the user.
+                    const remoteCfg = await fetchGurukulConfig(identity.userId);
+                    setRemoteConfig(remoteCfg);
+
                     // Redirect users to library based on group configuration
-                    const config = getGroupConfig(identity.group);
+                    const config = { ...getGroupConfig(identity.group), ...remoteCfg };
                     if (pathname === '/' && config.showHomeTab === false) {
                         router.replace('/library');
                     }
@@ -203,6 +212,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     }, []);
 
     const userName = `${user?.first_name || ''} ${user?.last_name || ''}`.trim();
+
+    // Hardcoded group defaults overlaid with the backend-resolved config.
+    const groupConfig = useMemo(
+        () => ({ ...getGroupConfig(group || 'defaultGroup'), ...remoteConfig }),
+        [group, remoteConfig]
+    );
 
     const logout = async () => {
         try {
@@ -245,6 +260,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
                 apaarId,
                 logout,
                 isLoading,
+                groupConfig,
             }}
         >
             {children}


### PR DESCRIPTION
## What

Switches Gurukul's UI configuration source from the hardcoded, per-`auth_group` `groupConfig` to a **per-user config resolved by db-service**, while keeping the hardcoded values as a safe fallback.

This is the frontend half of moving Gurukul UI config to per-program/batch for the AY26-27 launch (Gurukul going to all programs, not just PMU). Backend side: db-service PRs avantifellows/db-service#529 (storage) and #530 (resolution endpoint).

## How

- **`api/afdb/gurukulConfig.ts`** (new server action): calls `GET /api/gurukul-config?user_id=…` on db-service, which resolves the config along the chain `batch → program → defaultgroup` (later wins). Returns a **partial** config; returns `{}` on any error.
- **`AuthContext`**: after token verification, fetches the user's config and exposes a merged `groupConfig` via `useAuth()` — `getGroupConfig(group)` (hardcoded defaults) overlaid with the backend response.
- **Consumers** (`app/page.tsx`, `app/library/page.tsx`, `app/reports/reports_list.tsx`, `app/loading.js`, `components/BottomNavigationBar.tsx`): now read `groupConfig` from `useAuth()` instead of calling `getGroupConfig` directly.

## Safety / rollout

- **No behavior change until backend configs are populated.** db-service currently has no `defaultgroup`/program/batch configs, so the endpoint returns `{}`, the overlay is empty, and components render exactly as today on the hardcoded defaults.
- The hardcoded `config/groupConfig.ts` is intentionally **kept** as the base layer and fallback (network failure → `{}` → defaults intact). It can be retired later once backend configs fully cover all groups.
- The bearer token stays server-side (the fetch is a `"use server"` action, matching the existing `getUserDetails` pattern).

## Testing

- `npx tsc --noEmit` — clean
- `npm run lint` — passes (only pre-existing `exhaustive-deps` warnings)
- `npm run build` — succeeds, all routes compile

## Follow-up (not in this PR)

Seed the `defaultgroup` auth_group and populate `program.config` / `batch.metadata["gurukul_config"]` in db-service from the config spreadsheet; then this overlay begins taking effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)