### PR TITLE
fix: resolve Gurukul config from backend, not the token group

### DIFF
--- a/services/AuthContext.tsx
+++ b/services/AuthContext.tsx
@@ -185,13 +185,15 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
                     }
 
                     // Resolve UI config from db-service (batch <- program <-
-                    // defaultgroup). Falls back to the hardcoded group defaults
-                    // when the backend has nothing configured for the user.
+                    // defaultgroup). The backend is the source of truth; the
+                    // local `defaultGroup` entry is only a neutral safety net
+                    // for keys the backend hasn't sent (or a failed fetch), so
+                    // we never leak a token-group's hardcoded branding.
                     const remoteCfg = await fetchGurukulConfig(identity.userId);
                     setRemoteConfig(remoteCfg);
 
                     // Redirect users to library based on group configuration
-                    const config = { ...getGroupConfig(identity.group), ...remoteCfg };
+                    const config = { ...getGroupConfig('defaultGroup'), ...remoteCfg };
                     if (pathname === '/' && config.showHomeTab === false) {
                         router.replace('/library');
                     }
@@ -213,10 +215,13 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
     const userName = `${user?.first_name || ''} ${user?.last_name || ''}`.trim();
 
-    // Hardcoded group defaults overlaid with the backend-resolved config.
+    // Backend-resolved config is the source of truth; the neutral
+    // `defaultGroup` entry only backstops keys the backend hasn't sent yet.
+    // We deliberately do NOT key the base off the token group, so a group's
+    // hardcoded branding (e.g. NVS labels) can never bleed through.
     const groupConfig = useMemo(
-        () => ({ ...getGroupConfig(group || 'defaultGroup'), ...remoteConfig }),
-        [group, remoteConfig]
+        () => ({ ...getGroupConfig('defaultGroup'), ...remoteConfig }),
+        [remoteConfig]
     );
 
     const logout = async () => {


### PR DESCRIPTION
## Problem

`AuthContext` resolved the UI config as:

```ts
{ ...getGroupConfig(tokenGroup), ...remoteConfig }
```

So any key the db-service `/gurukul-config` response didn't include fell through to the **hardcoded `groupConfig.ts` entry for the user's token group**. For NVS/CoE students that leaked `EnableStudents` branding even when the backend intended a neutral (or CoE) config — e.g.:

- `noTestsMessage` → "There is no NVS live test for today!"
- `testsInfoLink` → the nvslakshya URL
- `displayLabel` → "JNV NVS"

This is what Dhyanesh saw on staging: a CoE student still showing NVS labels.

## Fix

Base the config on the neutral `defaultGroup` entry instead of the token group, in both spots that build it:

```ts
{ ...getGroupConfig('defaultGroup'), ...remoteConfig }
```

The backend (`batch <- program <- DefaultGroup`) is the source of truth; the local `defaultGroup` only backstops keys the backend hasn't sent yet (or a failed fetch). The token group no longer feeds runtime config, so **no group's hardcoded branding can bleed through** — fixes the NVS labels *and* `testsInfoLink` (and any future key) in one place, instead of whack-a-mole blank-sentinels in the DB.

`groupConfig.ts` is intentionally kept — the login page still uses it to list groups by region — but it's no longer consulted for resolved runtime config.

## Testing

- `tsc --noEmit` passes clean.
- Pairs with db-service #551 (DefaultGroup base now reads from `locale_data`), which populates the backend config this overlay consumes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)