### PR TITLE
fix: session visibility uses date-aware occurrence end (continuous vs weekly)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,7 +9,7 @@ import { QuizSession, SessionOccurrence, MessageDisplayProps, Session, QuizCompl
 import Link from "next/link";
 import PrimaryButton from "@/components/Button";
 import Loading from "./loading";
-import { formatCurrentTime, formatSessionTime, formatQuizSessionTime, formatTime, isSessionActive, format12HrSessionTime } from "@/utils/dateUtils";
+import { formatCurrentTime, formatSessionTime, formatTime, isSessionActive, format12HrSessionTime } from "@/utils/dateUtils";
 import { MixpanelTracking } from "@/services/mixpanel";
 import { IoIosArrowDown as ExpandIcon, IoIosArrowUp as CollapseIcon } from 'react-icons/io';
 import { buildGurukulSessionUrl } from "@/utils/portalLinks";
@@ -56,7 +56,7 @@ export default function Home() {
  */
   const filterAndSortTests = (quizzes: QuizSession[]) => {
     const activeQuizzes = quizzes
-      .filter(quiz => isSessionActive(formatQuizSessionTime(quiz.session.end_time)))
+      .filter(quiz => isSessionActive(quiz.session.end_time))
       .filter(quiz => {
         const platformId = quiz.session.platform_id;
         const isCompleted = quizCompletionStatus[platformId] === true;
@@ -135,7 +135,7 @@ export default function Home() {
       return <MessageDisplay message="No more live classes are scheduled for today!" />;
     }
 
-    const activeLiveClasses = liveClasses.filter((data) => isSessionActive(formatSessionTime(data.end_time)));
+    const activeLiveClasses = liveClasses.filter((data) => isSessionActive(data.end_time));
 
     if (activeLiveClasses.length === 0) {
       return <MessageDisplay message="No more live classes are scheduled for today!" />;
@@ -247,14 +247,15 @@ export default function Home() {
   function renderButton(data: any) {
     const currentTime = new Date();
     const sessionStartTimeStr = formatSessionTime(data.start_time);
-    const sessionEndTimeStr = formatSessionTime(data.end_time);
     const currentTimeStr = formatCurrentTime(currentTime.toISOString());
 
     const sessionTime = new Date(`2000-01-01T${sessionStartTimeStr}`);
-    const sessionEndTime = new Date(`2000-01-01T${sessionEndTimeStr}`);
     const currentTimeObj = new Date(`2000-01-01T${currentTimeStr}`);
     const minutesUntilSessionStart = (sessionTime.getTime() - currentTimeObj.getTime()) / (1000 * 60);
-    const hasSessionNotEnded = sessionEndTime.getTime() > currentTimeObj.getTime();
+    // Date-aware so continuous / overnight windows (end runs into a later day) keep
+    // their Start button instead of falling back to "Starts at…" once the wall clock
+    // passes the end's time-of-day. See isSessionActive in utils/dateUtils.
+    const hasSessionNotEnded = isSessionActive(data.end_time);
 
     if (data.session && data.session.platform === 'meet') {
       if (minutesUntilSessionStart <= 5 && hasSessionNotEnded) {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -56,7 +56,12 @@ export default function Home() {
  */
   const filterAndSortTests = (quizzes: QuizSession[]) => {
     const activeQuizzes = quizzes
-      .filter(quiz => isSessionActive(quiz.session.end_time))
+      // Use the OCCURRENCE end (top-level end_time), not session.end_time. For a
+      // weekly session, session.end_time is the multi-day schedule span end, while
+      // the occurrence end_time is *today's* slot (e.g. 11am–1pm) — so an 11–1
+      // weekly correctly disappears after 1pm. For a continuous session the two
+      // coincide (one 24h window), so it stays visible across midnight.
+      .filter(quiz => isSessionActive(quiz.end_time ?? quiz.session.end_time))
       .filter(quiz => {
         const platformId = quiz.session.platform_id;
         const isCompleted = quizCompletionStatus[platformId] === true;
@@ -234,7 +239,7 @@ export default function Home() {
                 </div>
 
                 <div className="flex items-center">
-                  {renderButton(data.session)}
+                  {renderButton(data)}
                 </div>
               </div>
             </div>
@@ -245,17 +250,23 @@ export default function Home() {
   };
 
   function renderButton(data: any) {
+    // Callers pass an occurrence ({ end_time, session }) for live classes and the
+    // bare session for quizzes. Normalise: `occurrence` is whichever carries the
+    // occurrence-level end_time, `session` is always the session fields.
+    const occurrence = data;
+    const session = data.session ?? data;
+
     const currentTime = new Date();
-    const sessionStartTimeStr = formatSessionTime(data.start_time);
+    const sessionStartTimeStr = formatSessionTime(occurrence.start_time ?? session.start_time);
     const currentTimeStr = formatCurrentTime(currentTime.toISOString());
 
     const sessionTime = new Date(`2000-01-01T${sessionStartTimeStr}`);
     const currentTimeObj = new Date(`2000-01-01T${currentTimeStr}`);
     const minutesUntilSessionStart = (sessionTime.getTime() - currentTimeObj.getTime()) / (1000 * 60);
-    // Date-aware so continuous / overnight windows (end runs into a later day) keep
-    // their Start button instead of falling back to "Starts at…" once the wall clock
-    // passes the end's time-of-day. See isSessionActive in utils/dateUtils.
-    const hasSessionNotEnded = isSessionActive(data.end_time);
+    // Date-aware AND occurrence-scoped: for a weekly session this is *today's* slot
+    // end (e.g. 1pm) so it hides after 1pm; for a continuous 24h window it stays
+    // visible across midnight. See isSessionActive in utils/dateUtils.
+    const hasSessionNotEnded = isSessionActive(occurrence.end_time ?? session.end_time);
 
     if (data.session && data.session.platform === 'meet') {
       if (minutesUntilSessionStart <= 5 && hasSessionNotEnded) {
@@ -274,8 +285,8 @@ export default function Home() {
           </p>
         );
       }
-    } else if (data.platform === 'quiz') {
-      const isCompleted = quizCompletionStatus.hasOwnProperty(data.platform_id) && quizCompletionStatus[data.platform_id] === true;
+    } else if (session.platform === 'quiz') {
+      const isCompleted = quizCompletionStatus.hasOwnProperty(session.platform_id) && quizCompletionStatus[session.platform_id] === true;
       if (isCompleted) {
         return (
           <div className="flex flex-col items-center pr-2">
@@ -286,13 +297,13 @@ export default function Home() {
         );
       }
       if (minutesUntilSessionStart <= 5 && hasSessionNotEnded) {
-        const isResumeable = quizCompletionStatus.hasOwnProperty(data.platform_id) && !quizCompletionStatus[data.platform_id];
-        const formatType = data.meta_data?.gurukul_format_type || 'both';
+        const isResumeable = quizCompletionStatus.hasOwnProperty(session.platform_id) && !quizCompletionStatus[session.platform_id];
+        const formatType = session.meta_data?.gurukul_format_type || 'both';
         const showBothButtons = formatType === 'both';
 
         const renderQuizButton = formatType !== 'omr' ? (
           <div className="flex flex-col items-center">
-            <Link href={buildGurukulSessionUrl(data.session_id)} target="_blank">
+            <Link href={buildGurukulSessionUrl(session.session_id)} target="_blank">
               <PrimaryButton className={`${isResumeable ? "bg-resumeable" : "bg-primary"} text-white text-sm rounded-md w-[118px] md:w-36 h-8 shadow-slate-400`}>
                 {isResumeable ? "Resume" : "Start Test"}
               </PrimaryButton>
@@ -303,7 +314,7 @@ export default function Home() {
 
         const renderOmrButton = formatType !== 'qa' ? (
           <div className="flex flex-col items-center">
-            <Link href={buildGurukulSessionUrl(data.session_id, { omrMode: true })} target="_blank">
+            <Link href={buildGurukulSessionUrl(session.session_id, { omrMode: true })} target="_blank">
               <PrimaryButton className={`${isResumeable ? "bg-resumeable" : "bg-primary"} text-white text-sm rounded-md w-[118px] md:w-36 h-8 shadow-slate-400`}>
                 {isResumeable ? "Resume" : "Fill OMR"}
               </PrimaryButton>
@@ -322,7 +333,7 @@ export default function Home() {
         return (
           <p className="text-xs italic font-normal mr-4 w-14">
             Starts at <br />
-            {format12HrSessionTime(data.start_time)}
+            {format12HrSessionTime(occurrence.start_time ?? session.start_time)}
           </p>
         );
       }
@@ -447,7 +458,7 @@ export default function Home() {
                                     </div>
                                   </div>
                                   <div className="flex items-center">
-                                    {renderButton(test.session)}
+                                    {renderButton(test)}
                                   </div>
                                 </div>
                               </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,7 +9,7 @@ import { QuizSession, SessionOccurrence, MessageDisplayProps, Session, QuizCompl
 import Link from "next/link";
 import PrimaryButton from "@/components/Button";
 import Loading from "./loading";
-import { formatCurrentTime, formatSessionTime, formatTime, isSessionActive, format12HrSessionTime } from "@/utils/dateUtils";
+import { formatSessionTime, formatTime, isSessionActive, minutesUntilStart, format12HrSessionTime, formatSessionTimeRange } from "@/utils/dateUtils";
 import { MixpanelTracking } from "@/services/mixpanel";
 import { IoIosArrowDown as ExpandIcon, IoIosArrowUp as CollapseIcon } from 'react-icons/io';
 import { buildGurukulSessionUrl } from "@/utils/portalLinks";
@@ -228,7 +228,7 @@ export default function Home() {
 
                 <div className="flex flex-col gap-1 pl-6 sm:w-full w-48 md:w-full text-sm md:text-base">
                   <div className="absolute top-2 left-6 text-gray-700 text-xs md:text-sm whitespace-nowrap">
-                    {format12HrSessionTime(data.session.start_time)} - {format12HrSessionTime(data.session.end_time)}
+                    {formatSessionTimeRange(data.start_time ?? data.session.start_time, data.end_time ?? data.session.end_time)}
                   </div>
                   <div className="font-semibold">
                     {data.session.name}
@@ -256,16 +256,14 @@ export default function Home() {
     const occurrence = data;
     const session = data.session ?? data;
 
-    const currentTime = new Date();
-    const sessionStartTimeStr = formatSessionTime(occurrence.start_time ?? session.start_time);
-    const currentTimeStr = formatCurrentTime(currentTime.toISOString());
+    const occurrenceStart = occurrence.start_time ?? session.start_time;
+    const sessionStartTimeStr = formatSessionTime(occurrenceStart);
 
-    const sessionTime = new Date(`2000-01-01T${sessionStartTimeStr}`);
-    const currentTimeObj = new Date(`2000-01-01T${currentTimeStr}`);
-    const minutesUntilSessionStart = (sessionTime.getTime() - currentTimeObj.getTime()) / (1000 * 60);
-    // Date-aware AND occurrence-scoped: for a weekly session this is *today's* slot
-    // end (e.g. 1pm) so it hides after 1pm; for a continuous 24h window it stays
-    // visible across midnight. See isSessionActive in utils/dateUtils.
+    // Both date-aware (full timestamps), so a continuous / overnight window that
+    // opened on a PREVIOUS day still reads as already-started (negative) and not
+    // yet ended. Time-of-day-only math wrongly showed "Starts at…" the morning
+    // after. See minutesUntilStart / isSessionActive in utils/dateUtils.
+    const minutesUntilSessionStart = minutesUntilStart(occurrenceStart);
     const hasSessionNotEnded = isSessionActive(occurrence.end_time ?? session.end_time);
 
     if (data.session && data.session.platform === 'meet') {
@@ -448,7 +446,7 @@ export default function Home() {
                                   <div className={`${idx % 2 === 0 ? 'bg-orange-200' : 'bg-red-200'} h-full w-2 absolute left-0 top-0 rounded-s-md`} />
                                   <div className="flex flex-col gap-1 pl-6 sm:w-full w-48 md:w-full text-sm md:text-base">
                                     <div className="absolute top-2 left-6 text-gray-700 text-xs md:text-sm whitespace-nowrap">
-                                      {format12HrSessionTime(test.session.start_time)} - {format12HrSessionTime(test.session.end_time)}
+                                      {formatSessionTimeRange(test.start_time ?? test.session.start_time, test.end_time ?? test.session.end_time)}
                                     </div>
                                     <div className="font-semibold">
                                       {test.session.name}

--- a/app/types.ts
+++ b/app/types.ts
@@ -174,6 +174,11 @@ export interface Teacher {
 }
 
 export interface QuizSession {
+  // Occurrence-level window for this instance. session.end_time is the schedule
+  // SPAN end (multi-day for weekly); this is *today's* slot end. Optional because
+  // some legacy/non-occurrence shapes only carry the nested session.
+  end_time?: string,
+  start_time?: string,
   session: {
     batch: string,
     end_date: string,

--- a/utils/dateUtils.ts
+++ b/utils/dateUtils.ts
@@ -56,12 +56,29 @@ export function format12HrSessionTime(time: string): string {
     return `${formattedHours}:${formattedMinutes} ${period}`;
 }
 
+// IST is the wall-clock basis for all session start/end times the backend returns
+// (they arrive as IST-local values tagged with a literal "Z"). Used to express
+// "now" on the same basis when comparing full timestamps.
+const IST_OFFSET_MS = 5.5 * 60 * 60 * 1000;
+
+/**
+ * Whether a session's response window is still open.
+ *
+ * Accepts the FULL end timestamp (e.g. "2026-06-30T17:43:30Z") and compares it
+ * date-and-time-aware against now. Previously this compared only the time-of-day
+ * (both sides pinned to 2000-01-01), which silently treated any session whose end
+ * clock-time had already passed *today* as ended — even when the window actually
+ * runs into tomorrow. That hid every continuous / overnight session (24h windows,
+ * teacher-feedback forms, late-evening tests) once the wall clock passed the end's
+ * HH:MM, despite ~hours still remaining.
+ *
+ * The end string is IST wall-clock tagged "Z", so new Date(endTime).getTime() is
+ * "IST as if UTC"; we shift real-now by +IST so both sides share that basis.
+ */
 export function isSessionActive(endTime: string): boolean {
-    const currentTime = new Date();
-    const currentTimeStr = formatCurrentTime(currentTime.toISOString());
-    const sessionEndTime = new Date(`2000-01-01T${endTime}`);
-    const currentTimeObj = new Date(`2000-01-01T${currentTimeStr}`);
-    return sessionEndTime.getTime() > currentTimeObj.getTime();
+    const sessionEndTime = new Date(endTime).getTime();
+    const nowSameBasis = Date.now() + IST_OFFSET_MS;
+    return sessionEndTime > nowSameBasis;
 }
 
 export function formatDate(dateStr: string): string {

--- a/utils/dateUtils.ts
+++ b/utils/dateUtils.ts
@@ -56,6 +56,28 @@ export function format12HrSessionTime(time: string): string {
     return `${formattedHours}:${formattedMinutes} ${period}`;
 }
 
+const MONTHS_SHORT = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+/**
+ * "5:43 PM - 7:00 PM" for a same-day window, or
+ * "29 Jun 5:43 PM - 30 Jun 5:43 PM" when start and end fall on different days
+ * (e.g. a continuous 24h window). Avoids a 24h span reading as "5:43 - 5:43".
+ * Uses the same UTC-getter basis as format12HrSessionTime (IST-tagged-"Z").
+ */
+export function formatSessionTimeRange(start: string, end: string): string {
+    const s = new Date(start);
+    const e = new Date(end);
+    const sameDay =
+        s.getUTCFullYear() === e.getUTCFullYear() &&
+        s.getUTCMonth() === e.getUTCMonth() &&
+        s.getUTCDate() === e.getUTCDate();
+    const datePrefix = (d: Date) => `${d.getUTCDate()} ${MONTHS_SHORT[d.getUTCMonth()]} `;
+    if (sameDay) {
+        return `${format12HrSessionTime(start)} - ${format12HrSessionTime(end)}`;
+    }
+    return `${datePrefix(s)}${format12HrSessionTime(start)} - ${datePrefix(e)}${format12HrSessionTime(end)}`;
+}
+
 // IST is the wall-clock basis for all session start/end times the backend returns
 // (they arrive as IST-local values tagged with a literal "Z"). Used to express
 // "now" on the same basis when comparing full timestamps.
@@ -79,6 +101,21 @@ export function isSessionActive(endTime: string): boolean {
     const sessionEndTime = new Date(endTime).getTime();
     const nowSameBasis = Date.now() + IST_OFFSET_MS;
     return sessionEndTime > nowSameBasis;
+}
+
+/**
+ * Minutes from now until a session's start (negative once it has started).
+ *
+ * Accepts the FULL start timestamp and is date-aware, on the same IST-tagged-"Z"
+ * basis as isSessionActive. Previously the caller derived this from time-of-day
+ * only, so a session that started on a PREVIOUS day (e.g. a 24h window opened
+ * yesterday) read as "starts in ~N hours today" and never showed its Start
+ * button the morning after. Now a session already underway is correctly negative.
+ */
+export function minutesUntilStart(startTime: string): number {
+    const start = new Date(startTime).getTime();
+    const nowSameBasis = Date.now() + IST_OFFSET_MS;
+    return (start - nowSameBasis) / (1000 * 60);
 }
 
 export function formatDate(dateStr: string): string {


### PR DESCRIPTION
## Problem

Session visibility / the Start button broke for **continuous & overnight sessions** (24h windows, teacher-feedback forms, late-evening tests). Three compounding date-blindness bugs, all from comparing **time-of-day only** (values pinned to `2000-01-01T${hh:mm}`) instead of full timestamps:

1. **`isSessionActive`** treated a session whose end *clock-time* had passed today as ended — even when its window ran into a later day. → overnight session vanished ~hours early.
2. **Wrong field**: visibility checked `session.end_time` (the multi-day *schedule span* end) instead of the **occurrence** end. → a weekly 11am–1pm slot would stay visible all day for the whole range.
3. **`minutesUntilSessionStart`** (the `<= 5` Start-button gate) was also time-of-day only, so a session that *started yesterday* (a 24h window) read as "starts in ~N hours today" and showed **"Starts at…"** with no Start button the morning after.

Plus a cosmetic issue: the card printed start/end time-of-day only, so a 24h window read as **"5:43 PM - 5:43 PM"**.

## Example (real staging data)

Feedback session 17330: occurrence `29 Jun 17:43` → `30 Jun 17:43` (a 24h window).

| When | Old behaviour | Fixed |
|---|---|---|
| 29 Jun, 18:15 (same evening) | hidden (`end 17:43 < now 18:15`, time-only) | visible ✅ |
| 30 Jun, 09:54 (next morning) | card shows, but "Starts at 5:43 PM", no button (`minUntilStart = +469`) | **Start button** ✅ |
| weekly 11am–1pm, after 1pm | stayed till span end | hidden after 1pm ✅ |
| label for 24h window | "5:43 PM - 5:43 PM" | "29 Jun 5:43 PM - 30 Jun 5:43 PM" ✅ |

## Fix

- `isSessionActive(endTime)` and new `minutesUntilStart(startTime)` compare **full timestamps** vs now (end strings are IST wall-clock tagged `Z`; now is shifted by +IST to share that basis).
- Visibility (`filterAndSortTests`) and the button gate (`renderButton`) use the **occurrence** start/end, not the schedule span.
- `renderButton` was called with two shapes (occurrence for live classes, bare session for quizzes); normalised to always receive the occurrence and derive `session = data.session ?? data`. `QuizSession` gains optional occurrence-level `end_time`/`start_time`.
- New `formatSessionTimeRange(start, end)` adds a date prefix only when start/end fall on different days; same-day labels unchanged.

## Verification (simulated against the patched logic)

Visibility: weekly before/after slot, continuous same-day / across-midnight / after-end — all correct.
Button gate: morning-after a 24h window → Start ✅; just-started → Start ✅; before start (>5m) → "Starts at…" ✅; after end → hidden ✅.
Label: 24h → "29 Jun 5:43 PM - 30 Jun 5:43 PM"; same-day → "6:04 PM - 10:04 PM".

`tsc --noEmit` clean; eslint clean on changed files (1 pre-existing unrelated `exhaustive-deps` warning).

## Scope / safety

Same-day single-slot behaviour is unchanged throughout; only date-spanning / weekly-span / morning-after cases are corrected. `isSessionActive` is shared by both quiz and live-class filters and keeps identical same-day semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)