### PR TITLE
fix: stop hiding chapter tests for EnableStudents group

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,7 +15,7 @@ import { IoIosArrowDown as ExpandIcon, IoIosArrowUp as CollapseIcon } from 'reac
 import { buildGurukulSessionUrl } from "@/utils/portalLinks";
 
 export default function Home() {
-  const { loggedIn, userId, group, groupConfig, isLoading: authLoading } = useAuth();
+  const { loggedIn, userId, groupConfig, isLoading: authLoading } = useAuth();
   const [liveClasses, setLiveClasses] = useState<SessionOccurrence[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [quizzes, setQuizzes] = useState<QuizSession[]>([]);
@@ -77,8 +77,7 @@ export default function Home() {
       quiz.session.meta_data.test_format !== 'chapter_test'
     );
 
-    // Hide chapter tests for EnableStudents group
-    const chapterTests = group === 'EnableStudents' ? [] : regularTests.filter(quiz =>
+    const chapterTests = regularTests.filter(quiz =>
       quiz.session.meta_data.test_format === 'chapter_test'
     );
 


### PR DESCRIPTION
## Summary
- Remove the special case that hid chapter tests for the `EnableStudents` group — chapter tests are now shown to these users like any other group
- Drop the now-unused `group` value from the `useAuth()` destructuring in `app/page.tsx`

## Context
Chapter tests were intentionally hidden for EnableStudents earlier, but we no longer want that behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)