### PR TITLE
feat: fetch occurrences by explicit time window, not is_start_time=today

### DIFF
--- a/api/afdb/session.ts
+++ b/api/afdb/session.ts
@@ -1,18 +1,23 @@
 "use server"
 
 import getFetchConfig from '../fetchConfig';
+import { istNow, istEndOfToday } from '@/utils/dateUtils';
 
 const url = process.env.AF_DB_SERVICE_URL;
 const bearerToken = process.env.AF_DB_SERVICE_BEARER_TOKEN || '';
 
 export const getSessionOccurrences = async (sessionIds: string[]) => {
   try {
+    // Fetch every occurrence overlapping [now, end of today]: sessions open
+    // right now (however long ago they started) plus ones starting later
+    // today. The UI decides what's joinable vs "Starts at ..." client-side.
     const response = await fetch(`${url}/session-occurrence/search`, {
       ...getFetchConfig(bearerToken, { 'Content-Type': 'application/json' }),
       method: 'POST',
       body: JSON.stringify({
         session_ids: sessionIds,
-        is_start_time: 'today'
+        end_time_gte: istNow(),
+        start_time_lte: istEndOfToday()
       }),
       cache: 'no-store'
     });

--- a/utils/dateUtils.ts
+++ b/utils/dateUtils.ts
@@ -118,6 +118,25 @@ export function minutesUntilStart(startTime: string): number {
     return (start - nowSameBasis) / (1000 * 60);
 }
 
+/**
+ * Current time as an IST-wall-clock ISO string tagged "Z" — the same basis the
+ * backend stores session times in, so it can be sent as a query boundary.
+ */
+export function istNow(): string {
+    return new Date(Date.now() + IST_OFFSET_MS).toISOString().replace(/\.\d{3}Z$/, 'Z');
+}
+
+/**
+ * Today's 23:59:59 IST on the same IST-tagged-"Z" basis as istNow. Together
+ * they bound the home page's fetch window: everything still open now through
+ * everything starting later today.
+ */
+export function istEndOfToday(): string {
+    const endOfToday = new Date(Date.now() + IST_OFFSET_MS);
+    endOfToday.setUTCHours(23, 59, 59, 0);
+    return endOfToday.toISOString().replace(/\.\d{3}Z$/, 'Z');
+}
+
 export function formatDate(dateStr: string): string {
     const [year, month, day] = dateStr.split('-');
     return `${day}-${month}-${year}`;


### PR DESCRIPTION
## Problem
A **continuous** session (one occurrence spanning e.g. 9 Jul 2pm–6pm) never showed on the home page before opening — at 1pm students saw "no tests right now" instead of "Starts at 2:00 PM". The backend's `is_start_time=today` filter returns continuous occurrences only while they are already active, so the occurrence never reached the client, even though the pre-start UI (`renderButton`'s "Starts at …" state) already handles it.

Repro: user 274290217514 (EnableStudents), session 17462.

## Change
Per the design discussion (Pritam): db-service stays a dumb time-range query; Gurukul owns "visible today / starts soon" logic.

- `getSessionOccurrences` now sends an explicit overlap window instead of `is_start_time: 'today'`:
  - `end_time_gte: <now IST>` — everything still open, however long ago it started (covers multi-day continuous sessions)
  - `start_time_lte: <23:59:59 today IST>` — plus everything starting later today
- New `istNow()` / `istEndOfToday()` helpers in `utils/dateUtils.ts`, on the same IST-wall-clock-tagged-"Z" basis as the backend's stored times.
- No `app/page.tsx` changes needed: the end-time filter passes future-start occurrences through, and `renderButton` already shows "Starts at …" until 5 minutes before start.

Widening the window later (e.g. showing tomorrow's tests) is now a one-line client change.

## Deploy order
⚠️ Depends on avantifellows/db-service#595 — deploy that first. Until then this would return a 400 from `/session-occurrence/search` (unknown-param atoms error on old backend).

## Verification
- `tsc --noEmit` and ESLint clean.
- Helper output verified: `istNow() → 2026-07-10T14:09:43Z` (IST wall-clock), `istEndOfToday() → 2026-07-10T23:59:59Z`.
- After both deploys: log in as the repro user before the session window opens → test should list with "Starts at 2:20 PM"; within 5 min of start → Start button; after end → gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)