### PR TITLE
Show form sessions in a dedicated Forms section

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -68,8 +68,15 @@ export default function Home() {
         return isQuizAttemptable(platformId) || isCompleted;
       });
 
+    // Forms (e.g. feedback questionnaires) ride on the quiz platform with
+    // test_type 'form'; they get their own section above the test sections.
+    const forms = activeQuizzes.filter(quiz =>
+      quiz.session.meta_data.test_type === 'form'
+    );
+
     const regularTests = activeQuizzes.filter(quiz =>
       quiz.session.meta_data.test_type !== 'homework' &&
+      quiz.session.meta_data.test_type !== 'form' &&
       quiz.session.meta_data.test_purpose !== 'practice_test'
     );
 
@@ -89,7 +96,7 @@ export default function Home() {
       quiz.session.meta_data.test_type === 'homework'
     );
 
-    return { nonChapterTests, chapterTests, practiceTests, homework };
+    return { forms, nonChapterTests, chapterTests, practiceTests, homework };
   };
 
   const fetchUserSessions = async () => {
@@ -296,12 +303,15 @@ export default function Home() {
         );
       }
     } else if (session.platform === 'quiz') {
+      // Forms (feedback questionnaires etc.) run on the quiz platform too;
+      // only the copy differs.
+      const isForm = session.meta_data?.test_type === 'form';
       const isCompleted = quizCompletionStatus.hasOwnProperty(session.platform_id) && quizCompletionStatus[session.platform_id] === true;
       if (isCompleted) {
         return (
           <div className="flex flex-col items-center pr-2">
             <div className="w-[118px] italic md:w-36 h-8 flex items-center justify-center text-xs">
-              Test Submitted
+              {isForm ? "Form Submitted" : "Test Submitted"}
             </div>
           </div>
         );
@@ -315,10 +325,10 @@ export default function Home() {
           <div className="flex flex-col items-center">
             <Link href={buildGurukulSessionUrl(session.session_id)} target="_blank">
               <PrimaryButton className={`${isResumeable ? "bg-resumeable" : "bg-primary"} text-white text-sm rounded-md w-[118px] md:w-36 h-8 shadow-slate-400`}>
-                {isResumeable ? "Resume" : "Start Test"}
+                {isResumeable ? "Resume" : (isForm ? "Fill Form" : "Start Test")}
               </PrimaryButton>
             </Link>
-            <div className={`text-gray-500 md:text-xs text-[10px] text-center ${showBothButtons ? 'pb-2' : ''}`}>Click to begin online test</div>
+            <div className={`text-gray-500 md:text-xs text-[10px] text-center ${showBothButtons ? 'pb-2' : ''}`}>{isForm ? "Click to fill the form" : "Click to begin online test"}</div>
           </div>
         ) : null;
 
@@ -375,7 +385,7 @@ export default function Home() {
     }
   }, [loggedIn, userId, authLoading]);
 
-  const { nonChapterTests, chapterTests, practiceTests, homework } = filterAndSortTests(quizzes);
+  const { forms, nonChapterTests, chapterTests, practiceTests, homework } = filterAndSortTests(quizzes);
 
   // --- Practice Test Accordion UI for all groups ---
   // Filter and group practice tests by format
@@ -428,6 +438,9 @@ export default function Home() {
           )}
 
           <div className="pb-40">
+            {/* Only rendered when there are active forms — no empty-state
+                message, so students never see "no more forms" on a normal day. */}
+            {forms.length > 0 && renderTestSection("Forms", forms)}
             {groupConfig.showTests && renderTestSection(groupConfig.testsSectionTitle || "Tests", nonChapterTests)}
             {groupConfig.showChapterTests && renderTestSection("Chapter Tests", chapterTests)}
             {/* Practice Tests Accordion for all groups */}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -318,7 +318,9 @@ export default function Home() {
       }
       if (minutesUntilSessionStart <= 5 && hasSessionNotEnded) {
         const isResumeable = quizCompletionStatus.hasOwnProperty(session.platform_id) && !quizCompletionStatus[session.platform_id];
-        const formatType = session.meta_data?.gurukul_format_type || 'both';
+        // Forms have no OMR variant, so they are always 'qa' regardless of
+        // gurukul_format_type metadata (which is sometimes missing anyway).
+        const formatType = isForm ? 'qa' : (session.meta_data?.gurukul_format_type || 'both');
         const showBothButtons = formatType === 'both';
 
         const renderQuizButton = formatType !== 'omr' ? (


### PR DESCRIPTION
## Summary
- Form sessions (`meta_data.test_type: "form"`, e.g. feedback questionnaires) run on the quiz platform and were previously mixed into the main Tests section — they now get their own **Forms** section rendered above the test sections
- The Forms section only renders when there are active form sessions, so there is **no "no more forms" empty-state message** on days without forms (addresses Poojita's feedback)
- Forms are excluded from the regular Tests list so they don't show twice
- Copy is form-aware: the action button says **"Fill Form"** (helper text "Click to fill the form") and the completed state says **"Form Submitted"** instead of "Start Test" / "Test Submitted"

## Notes
- No new group config flag: forms ride along with the existing quiz fetch, so groups that don't fetch quizzes (showTests/showPracticeTests/showHomework all false) never see the section
- Resume behavior for partially-filled forms works the same as quizzes (shows "Resume")

## Test plan
- [ ] Log in as a user in a batch with an active form session (test_type `form`) — a "Forms" heading should appear above the tests section with the form card
- [ ] Confirm the form no longer also appears in the main Tests section
- [ ] On a day with no active forms, confirm no Forms heading or empty message appears
- [ ] Click "Fill Form" — should open the portal session link like a quiz
- [ ] Submit the form and confirm the card shows "Form Submitted"

🤖 Generated with [Claude Code](https://claude.com/claude-code)