### PR TITLE
feat: merge chapter tests into Tests section, add showForms flag

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -74,18 +74,12 @@ export default function Home() {
       quiz.session.meta_data.test_type === 'form'
     );
 
-    const regularTests = activeQuizzes.filter(quiz =>
+    // Chapter tests are deliberately NOT split out — they render in the same
+    // Tests section as every other regular test.
+    const tests = activeQuizzes.filter(quiz =>
       quiz.session.meta_data.test_type !== 'homework' &&
       quiz.session.meta_data.test_type !== 'form' &&
       quiz.session.meta_data.test_purpose !== 'practice_test'
-    );
-
-    const nonChapterTests = regularTests.filter(quiz =>
-      quiz.session.meta_data.test_format !== 'chapter_test'
-    );
-
-    const chapterTests = regularTests.filter(quiz =>
-      quiz.session.meta_data.test_format === 'chapter_test'
     );
 
     const practiceTests = activeQuizzes.filter(quiz =>
@@ -96,13 +90,13 @@ export default function Home() {
       quiz.session.meta_data.test_type === 'homework'
     );
 
-    return { forms, nonChapterTests, chapterTests, practiceTests, homework };
+    return { forms, tests, practiceTests, homework };
   };
 
   const fetchUserSessions = async () => {
     setIsLoading(true);
     try {
-      const shouldFetchQuizzes = groupConfig.showTests || groupConfig.showPracticeTests || groupConfig.showHomework;
+      const shouldFetchQuizzes = groupConfig.showTests || groupConfig.showForms || groupConfig.showPracticeTests || groupConfig.showHomework;
 
       const numericUserId = Number(userId);
 
@@ -189,8 +183,8 @@ export default function Home() {
       switch (title.toLowerCase()) {
         case 'tests':
           return groupConfig.showTests;
-        case 'chapter tests':
-          return groupConfig.showChapterTests;
+        case 'forms':
+          return groupConfig.showForms;
         case 'practice tests':
           return groupConfig.showPracticeTests;
         case 'homework':
@@ -203,17 +197,6 @@ export default function Home() {
     if (!shouldShow) return null;
 
     if (tests.length === 0) {
-      // noTestsMessage is worded for the main live-test section (e.g. "There is
-      // no NVS live test for today!"), so don't reuse it under Chapter Tests.
-      const isChapterTestSection = title.toLowerCase() === 'chapter tests';
-      if (isChapterTestSection) {
-        return (
-          <div>
-            <h2 className="text-primary ml-4 font-semibold text-xl mt-6">{title}</h2>
-            <MessageDisplay message="No more chapter tests are scheduled for today!" />
-          </div>
-        );
-      }
       return (
         <div>
           <h2 className="text-primary ml-4 font-semibold text-xl mt-6">{title}</h2>
@@ -387,7 +370,7 @@ export default function Home() {
     }
   }, [loggedIn, userId, authLoading]);
 
-  const { forms, nonChapterTests, chapterTests, practiceTests, homework } = filterAndSortTests(quizzes);
+  const { forms, tests, practiceTests, homework } = filterAndSortTests(quizzes);
 
   // --- Practice Test Accordion UI for all groups ---
   // Filter and group practice tests by format
@@ -442,9 +425,8 @@ export default function Home() {
           <div className="pb-40">
             {/* Only rendered when there are active forms — no empty-state
                 message, so students never see "no more forms" on a normal day. */}
-            {forms.length > 0 && renderTestSection("Forms", forms)}
-            {groupConfig.showTests && renderTestSection(groupConfig.testsSectionTitle || "Tests", nonChapterTests)}
-            {groupConfig.showChapterTests && renderTestSection("Chapter Tests", chapterTests)}
+            {groupConfig.showForms && forms.length > 0 && renderTestSection("Forms", forms)}
+            {groupConfig.showTests && renderTestSection(groupConfig.testsSectionTitle || "Tests", tests)}
             {/* Practice Tests Accordion for all groups */}
             {groupConfig.showPracticeTests && (
               <div>

--- a/app/types.ts
+++ b/app/types.ts
@@ -217,7 +217,7 @@ export interface QuizCompletionStatus {
 export interface GroupConfig {
   showLiveClasses: boolean;
   showTests: boolean;
-  showChapterTests: boolean;
+  showForms: boolean;
   showPracticeTests: boolean;
   showHomework: boolean;
   showContentLibrary: boolean;

--- a/config/groupConfig.ts
+++ b/config/groupConfig.ts
@@ -4,7 +4,7 @@ const groupConfig: GroupConfigurations = {
     AllIndiaStudents: {
         showLiveClasses: false,
         showTests: true,
-        showChapterTests: true,
+        showForms: true,
         showPracticeTests: true,
         showHomework: false,
         showContentLibrary: true,
@@ -17,7 +17,7 @@ const groupConfig: GroupConfigurations = {
     EnableStudents: {
         showLiveClasses: false,
         showTests: true,
-        showChapterTests: true,
+        showForms: true,
         showPracticeTests: true,
         showHomework: false,
         showContentLibrary: true,
@@ -35,7 +35,7 @@ const groupConfig: GroupConfigurations = {
     EnableStudentsCoE: {
         showLiveClasses: false,
         showTests: true,
-        showChapterTests: true,
+        showForms: true,
         showPracticeTests: true,
         showHomework: false,
         showContentLibrary: true,
@@ -54,7 +54,7 @@ const groupConfig: GroupConfigurations = {
     EnableStudentsNodal: {
         showLiveClasses: false,
         showTests: true,
-        showChapterTests: true,
+        showForms: true,
         showPracticeTests: true,
         showHomework: false,
         showContentLibrary: true,
@@ -73,7 +73,7 @@ const groupConfig: GroupConfigurations = {
     EnableSchools: {
         showLiveClasses: false,
         showTests: false,
-        showChapterTests: false,
+        showForms: false,
         showPracticeTests: false,
         showHomework: false,
         showContentLibrary: true,
@@ -87,7 +87,7 @@ const groupConfig: GroupConfigurations = {
     DelhiStudents: {
         showLiveClasses: false,
         showTests: true,
-        showChapterTests: true,
+        showForms: true,
         showPracticeTests: true,
         showHomework: false,
         showContentLibrary: true,
@@ -101,7 +101,7 @@ const groupConfig: GroupConfigurations = {
     defaultGroup: {
         showLiveClasses: true,
         showTests: true,
-        showChapterTests: true,
+        showForms: true,
         showPracticeTests: true,
         showHomework: true,
         showContentLibrary: true,
@@ -112,7 +112,7 @@ const groupConfig: GroupConfigurations = {
     ChhattisgarhStudents: {
         showLiveClasses: false,
         showTests: true,
-        showChapterTests: true,
+        showForms: true,
         showPracticeTests: true,
         showHomework: false,
         showContentLibrary: true,
@@ -125,7 +125,7 @@ const groupConfig: GroupConfigurations = {
     PunjabStudents: {
         showLiveClasses: false,
         showTests: true,
-        showChapterTests: true,
+        showForms: true,
         showPracticeTests: false,
         showHomework: false,
         showContentLibrary: true,
@@ -139,7 +139,7 @@ const groupConfig: GroupConfigurations = {
     PunjabTeachers: {
         showLiveClasses: false,
         showTests: false,
-        showChapterTests: false,
+        showForms: false,
         showPracticeTests: false,
         showHomework: false,
         showContentLibrary: true,
@@ -153,7 +153,7 @@ const groupConfig: GroupConfigurations = {
     DelhiSchools: {
         showLiveClasses: false,
         showTests: false,
-        showChapterTests: false,
+        showForms: false,
         showPracticeTests: false,
         showHomework: false,
         showContentLibrary: true,
@@ -168,7 +168,7 @@ const groupConfig: GroupConfigurations = {
     HimachalStudents: {
         showLiveClasses: false,
         showTests: true,
-        showChapterTests: true,
+        showForms: true,
         showPracticeTests: false,
         showHomework: false,
         showContentLibrary: true,
@@ -182,7 +182,7 @@ const groupConfig: GroupConfigurations = {
     UttarakhandStudents: {
         showLiveClasses: false,
         showTests: true,
-        showChapterTests: true,
+        showForms: true,
         showPracticeTests: false,
         showHomework: false,
         showContentLibrary: true,
@@ -196,7 +196,7 @@ const groupConfig: GroupConfigurations = {
     MaharashtraStudents: {
         showLiveClasses: false,
         showTests: true,
-        showChapterTests: true,
+        showForms: true,
         showPracticeTests: true,
         showHomework: false,
         showContentLibrary: true,
@@ -210,7 +210,7 @@ const groupConfig: GroupConfigurations = {
     TNTeachers: {
         showLiveClasses: false,
         showTests: true,
-        showChapterTests: true,
+        showForms: true,
         showPracticeTests: false,
         showHomework: false,
         showContentLibrary: false,


### PR DESCRIPTION
## Changes

### Chapter tests back in the main Tests section
- Removed the separate **Chapter Tests** heading/section — chapter tests now render in the same Tests section as every other regular test (no more `test_format === 'chapter_test'` split in `filterAndSortTests`).
- Removed the `showChapterTests` flag from `GroupConfig` and all group entries, plus its chapter-test-specific empty-state message.

### `showForms` config flag
- New required `showForms` boolean on `GroupConfig`, mirroring `showLiveClasses`: when `false`, the entire Forms section is hidden even if form sessions exist.
- `showForms` also counts toward `shouldFetchQuizzes`, so a group with only forms enabled still fetches quiz sessions.
- Hardcoded group entries get `showForms: true` wherever they previously showed quiz content (`false` for EnableSchools, PunjabTeachers, DelhiSchools).

> **Note for db-service config:** since the effective config is `defaultGroup` + backend overlay, the backend key must be exactly `showForms` (plural) to disable forms for a batch/program. `defaultGroup` has `showForms: true`, so behavior is unchanged until the backend sends `showForms: false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)